### PR TITLE
Miscellous fixes and improments

### DIFF
--- a/leanblueprint/Packages/blueprint.py
+++ b/leanblueprint/Packages/blueprint.py
@@ -344,7 +344,7 @@ def ProcessOptions(options, document):
         """Build url for Lean 4 declarations referred to in the blueprint"""
 
         project_dochome = document.userdata.get('project_dochome',
-                                               'https://leanprover-community.github.io/mathlib4_docs/')
+                                               'https://leanprover-community.github.io/mathlib4_docs')
 
         nodes = []
         for thm_type in document.userdata['thm_types']:
@@ -355,7 +355,7 @@ def ProcessOptions(options, document):
             for leandecl in leandecls:
                 lean_urls.append(
                     (leandecl,
-                    f'{project_dochome}/find/?pattern={leandecl}#doc'))
+                    f'{project_dochome}/find/#doc/{leandecl}'))
 
             node.userdata['lean_urls'] = lean_urls
 

--- a/leanblueprint/templates/dep_graph.html
+++ b/leanblueprint/templates/dep_graph.html
@@ -90,7 +90,7 @@
       <span class="lean_link">Lean</span>
       <ul class="tooltip_list">
         {% for name, url in thm.userdata['lean_urls'] %}
-           <li><a href="{{ url }}">{{ name }}</a></li>
+           <li><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ name }}</a></li>
         {% endfor %}
       </ul>
   </div>

--- a/leanblueprint/templates/dep_graph.html
+++ b/leanblueprint/templates/dep_graph.html
@@ -95,7 +95,7 @@
       </ul>
   </div>
     {%- else -%}
-    <a class="lean_link" href="{{ thm.userdata['lean_urls'][0][1] }}">Lean</a>
+    <a class="lean_link" href="{{ thm.userdata['lean_urls'][0][1] }}" target="_blank" rel="noopener noreferrer">Lean</a>
     {%- endif -%}
     {%- endif -%}
 


### PR DESCRIPTION
- fix: "Lean" links in the dependent graph, and multiple "Lean" links for one definition/theorem, these 2 edge cases were forgot to update, now they behave the same as in the blueprint main document
- improvement: no more extra`/` in url
- improvement: use `/find/#doc/{leandecl}` instead of `/find/?pattern={leandecl}#doc`, the latter sometimes has some browser jumping issues