### PR TITLE
No longer open Lean link in a new tab by default

### DIFF
--- a/leanblueprint/Packages/renderer_templates/blueprint.jinja2s
+++ b/leanblueprint/Packages/renderer_templates/blueprint.jinja2s
@@ -47,7 +47,7 @@ name: thmenv
     {% call modal('Lean declarations') %}
         <ul class="uses">
           {% for lean, url in obj.userdata.lean_urls %}
-          <li><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ lean }}</a></li>
+          <li><a href="{{ url }}" class="lean_decl">{{ lean }}</a></li>
           {% endfor %}
         </ul>
     {% endcall %}

--- a/leanblueprint/templates/dep_graph.html
+++ b/leanblueprint/templates/dep_graph.html
@@ -38,7 +38,9 @@
 {% endif %}
   <script type="text/javascript" src="{{ config.html5['mathjax-url'] }}">  </script>
 {% endif %}
-
+{% for css in config.html5.get('extra-css', []) %}
+<link rel="stylesheet" href="styles/{{ css }}" />
+{% endfor %}
 </head>
 
 <body>
@@ -155,7 +157,9 @@ function interactive() {
 }
 
 </script>
-
+{% for js in config.html5.get('extra-js', []) %}
+<script type="text/javascript" src="js/{{ js }}"></script>
+{% endfor %}
 </body>
 </html>
 

--- a/leanblueprint/templates/dep_graph.html
+++ b/leanblueprint/templates/dep_graph.html
@@ -90,12 +90,12 @@
       <span class="lean_link">Lean</span>
       <ul class="tooltip_list">
         {% for name, url in thm.userdata['lean_urls'] %}
-           <li><a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ name }}</a></li>
+           <li><a href="{{ url }}" class="lean_decl">{{ name }}</a></li>
         {% endfor %}
       </ul>
   </div>
     {%- else -%}
-    <a class="lean_link" href="{{ thm.userdata['lean_urls'][0][1] }}" target="_blank" rel="noopener noreferrer">Lean</a>
+    <a class="lean_link lean_decl" href="{{ thm.userdata['lean_urls'][0][1] }}">Lean</a>
     {%- endif -%}
     {%- endif -%}
 


### PR DESCRIPTION
as requested by @PatrickMassot [here](https://github.com/PatrickMassot/leanblueprint/pull/5#discussion_r1391922905) but add a class `lean_decl` so this behavior can be customized.

During the process, we make dep_graph support extra css/js too, this helps behavior consistency and allows the customization above apply to dep_graph.

Tested with https://github.com/utensil/lean-ga/tree/blueprint .